### PR TITLE
Add sheet mapper code

### DIFF
--- a/map.html
+++ b/map.html
@@ -1,99 +1,86 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
-"http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
+
 <head>
-    <script src='https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.js'></script>
-    <link href='https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.css' rel='stylesheet' />
-    <link href='style.css' rel='stylesheet' />
+    <!-- Mapbox -->
+    <script src="https://api.mapbox.com/mapbox-gl-js/v1.12.0/mapbox-gl.js"></script>
+    <link href="https://api.mapbox.com/mapbox-gl-js/v1.12.0/mapbox-gl.css" rel="stylesheet" />
+
+    <!-- UIkit -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uikit@3.5.7/dist/css/uikit.min.css" />
+    <script src="https://cdn.jsdelivr.net/npm/uikit@3.5.7/dist/js/uikit.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/uikit@3.5.7/dist/js/uikit-icons.min.js"></script>
+
+    <!-- Other  -->
+    <script src='https://npmcdn.com/@turf/turf/turf.min.js'></script>
+    <script src='https://npmcdn.com/csv2geojson@latest/csv2geojson.js'></script>
+
+    <style>
+        body {
+            padding: 0;
+            margin: 0
+        }
+
+        #map {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            width: 100%;
+        }
+
+        #menu {
+            background: #fff;
+            position: absolute;
+            z-index: 1;
+            top: 10px;
+            left: 10px;
+            border-radius: 3px;
+            width: 120px;
+            border: 1px solid rgba(0, 0, 0, 0.4);
+            font-family: 'Open Sans', sans-serif;
+        }
+
+        #menu a {
+            font-size: 13px;
+            color: #404040;
+            display: block;
+            margin: 0;
+            padding: 0;
+            padding: 10px;
+            text-decoration: none;
+            border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+            text-align: center;
+        }
+
+        #menu a:last-child {
+            border: none;
+        }
+
+        #menu a:hover {
+            background-color: #f8f8f8;
+            color: #404040;
+        }
+
+        #menu a.active {
+            background-color: #3887be;
+            color: #ffffff;
+        }
+
+        #menu a.active:hover {
+            background: #3074a4;
+        }
+
+    </style>
+
 </head>
+
 <body>
-<nav id="menu"></nav>
-<div id="map"></div>
-<script>
 
-mapboxgl.accessToken = 'pk.eyJ1IjoiY2VudHJhbHBhcmthcmNoaXZlcyIsImEiOiJja2J3aXdtYzAwZ2ZrMnpucXhjcG9jbHdxIn0.eLl8yDer989epHWEfqABpA';
-var map = new mapboxgl.Map({
-    container: 'map',
-    pitch: 60,
-    style: 'mapbox://styles/centralparkarchives/ckdqg82ru045r19o3mwqadnj0', // stylesheet location
-    center: [24.912975,60.227151], // starting position [lng, lat]
-    zoom: 16, // starting zoom
-    hash: true
-});
+    <nav id="menu"></nav>
+    <div id="map"></div>
 
-// Add zoom and rotation controls to the map.
-map.addControl(new mapboxgl.NavigationControl());
 
-map.on('load', function() {
-    map.addSource('helsinki', {
-        'type': 'raster',
-        'tiles': [
-        'https://kartta.hel.fi/ws/geoserver/avoindata/wms?SERVICE=WMS&REQUEST=GetMap&SERVICE=WMS&VERSION=1.1.1&LAYERS=Vinovalovarjoste_2017_MDHS_varipinta_05m&STYLES=&FORMAT=image/png&BGCOLOR=0xFFFFFF&TRANSPARENT=TRUE&SRS=epsg:3857&bbox={bbox-epsg-3857}&WIDTH=256&HEIGHT=256'
-        ],
-        'tileSize': 256
-    });
-    map.addSource('noise', {
-        'type': 'raster',
-        'tiles': [
-        'https://kartta.hel.fi/ws/geoserver/avoindata/wms?SERVICE=WMS&REQUEST=GetMap&SERVICE=WMS&VERSION=1.1.1&LAYERS=1940_opaskartta&STYLES=&FORMAT=image/png&BGCOLOR=0xFFFFFF&TRANSPARENT=TRUE&SRS=epsg:3857&bbox={bbox-epsg-3857}&WIDTH=256&HEIGHT=256'
-        ],
-        'tileSize': 256
-    });
-
-    map.addLayer(
-    {
-        'id': 'helsinkilayer',
-        'type': 'raster',
-        'source': 'helsinki',
-        'paint': {}
-    },
-    'aeroway-line'
-    );
-
-    map.addLayer(
-    {
-        'id': 'noiselayer',
-        'type': 'raster',
-        'source': 'noise',
-        'paint': {}
-    },
-    'aeroway-line'
-    );
-});
-
-// enumerate ids of the layers
-var toggleableLayerIds = ['helsinkilayer', 'noiselayer'];
-
-// set up the corresponding toggle button for each layer
-for (var i = 0; i < toggleableLayerIds.length; i++) {
-var id = toggleableLayerIds[i];
- 
-var link = document.createElement('a');
-link.href = '#';
-link.className = 'active';
-link.textContent = id;
- 
-link.onclick = function(e) {
-var clickedLayer = this.textContent;
-e.preventDefault();
-e.stopPropagation();
- 
-var visibility = map.getLayoutProperty(clickedLayer, 'visibility');
- 
-// toggle layer visibility by changing the layout object's visibility property
-if (visibility === 'visible') {
-map.setLayoutProperty(clickedLayer, 'visibility', 'none');
-this.className = '';
-} else {
-this.className = 'active';
-map.setLayoutProperty(clickedLayer, 'visibility', 'visible');
-}
-};
- 
-var layers = document.getElementById('menu');
-layers.appendChild(link);
-}
-
-</script>
+    <script src="./map.js"></script>
 </body>
+
 </html>

--- a/map.html
+++ b/map.html
@@ -79,7 +79,6 @@
     <nav id="menu"></nav>
     <div id="map"></div>
 
-
     <script src="./map.js"></script>
 </body>
 

--- a/map.js
+++ b/map.js
@@ -11,9 +11,7 @@
         pitch: 60,
         style: 'mapbox://styles/centralparkarchives/ckdqg82ru045r19o3mwqadnj0', // stylesheet location
         center: [24.912975, 60.227151], // starting position [lng, lat]
-        zoom: 16, // starting zoom
-        transformRequest: transformRequest,
-        hash: true
+        zoom: 16
     });
 }
 
@@ -109,7 +107,7 @@ function loadMapLayers() {
     map.addSource('noise', {
         'type': 'raster',
         'tiles': [
-            'https://kartta.hel.fi/ws/geoserver/avoindata/wms?SERVICE=WMS&REQUEST=GetMap&SERVICE=WMS&VERSION=1.1.1&LAYERS=Meluselvitys_2017_alue_01_tieliikenne_L_Aeq_paiva&STYLES=&FORMAT=image/png&BGCOLOR=0xFFFFFF&TRANSPARENT=TRUE&SRS=epsg:3857&bbox={bbox-epsg-3857}&WIDTH=256&HEIGHT=256'
+            'https://kartta.hel.fi/ws/geoserver/avoindata/wms?SERVICE=WMS&REQUEST=GetMap&SERVICE=WMS&VERSION=1.1.1&LAYERS=1940_opaskartta&STYLES=&FORMAT=image/png&BGCOLOR=0xFFFFFF&TRANSPARENT=TRUE&SRS=epsg:3857&bbox={bbox-epsg-3857}&WIDTH=256&HEIGHT=256'
         ],
         'tileSize': 256
     });
@@ -185,7 +183,8 @@ function addMapInteractions() {
         //You can adjust the values of the popup to match the headers of your CSV. 
         // For example: e.features[0].properties.Name is retrieving information from the field Name in the original CSV. 
         var description = `<h4>${row.properties.place}</h4>`;
-        description += `<audio controls><source src="#" type="audio/ogg"></audio>`
+        var fileId='14JcrdS4FN9bPVK2OCvW6opInr8cN-mYK'
+        description += `<audio controls><source src="https://drive.google.com/uc?export=${fileId}" type="audio/ogg"></audio>`
         description += `<p>${row.properties["file name / link"]}</p>`
         description += `<p>${row.properties.comments}</p>`
         description += `<p>${row.properties.topics}</p>`
@@ -209,7 +208,7 @@ function addMapInteractions() {
             .addTo(map);
     });
 
-    // inspect a cluster on click
+    // inspect on click
     map.on('click', 'sheet-data', function (e) {
 
         var features = map.queryRenderedFeatures(e.point, {
@@ -232,17 +231,3 @@ function addMapInteractions() {
         map.getCanvas().style.cursor = '';
     });
 }
-
-//
-// Other functions
-//
-
-var transformRequest = (url, resourceType) => {
-    var isMapboxRequest =
-        url.slice(8, 22) === "api.mapbox.com" ||
-        url.slice(10, 26) === "tiles.mapbox.com";
-    return {
-        url: isMapboxRequest ?
-            url.replace("?", "?pluginName=sheetMapper&") : url
-    };
-};

--- a/map.js
+++ b/map.js
@@ -1,0 +1,248 @@
+//
+// Create Mapbox map
+//
+
+{
+    mapboxgl.accessToken =
+        'pk.eyJ1IjoiY2VudHJhbHBhcmthcmNoaXZlcyIsImEiOiJja2J3aXdtYzAwZ2ZrMnpucXhjcG9jbHdxIn0.eLl8yDer989epHWEfqABpA';
+
+    var map = new mapboxgl.Map({
+        container: 'map',
+        pitch: 60,
+        style: 'mapbox://styles/centralparkarchives/ckdqg82ru045r19o3mwqadnj0', // stylesheet location
+        center: [24.912975, 60.227151], // starting position [lng, lat]
+        zoom: 16, // starting zoom
+        transformRequest: transformRequest,
+        hash: true
+    });
+}
+
+//
+// Map controls
+//
+
+// Add zoom and rotation controls to the map.
+map.addControl(new mapboxgl.NavigationControl());
+
+// Add geolocate control to the map.
+map.addControl(
+    new mapboxgl.GeolocateControl({
+        positionOptions: {
+            enableHighAccuracy: true
+        },
+        trackUserLocation: true
+    })
+);
+
+//  Add layer toggles
+{
+    var toggleableLayerIds = ['helsinkilayer', 'noiselayer'];
+
+    // set up the corresponding toggle button for each layer
+    for (var i = 0; i < toggleableLayerIds.length; i++) {
+        var id = toggleableLayerIds[i];
+
+        var link = document.createElement('a');
+        link.href = '#';
+        link.className = 'active';
+        link.textContent = id;
+
+        link.onclick = function (e) {
+            var clickedLayer = this.textContent;
+            e.preventDefault();
+            e.stopPropagation();
+
+            var visibility = map.getLayoutProperty(clickedLayer, 'visibility');
+
+            // toggle layer visibility by changing the layout object's visibility property
+            if (visibility === 'visible') {
+                map.setLayoutProperty(clickedLayer, 'visibility', 'none');
+                this.className = '';
+            } else {
+                this.className = 'active';
+                map.setLayoutProperty(clickedLayer, 'visibility', 'visible');
+            }
+        };
+
+
+        var layers = document.getElementById('menu');
+        layers.appendChild(link);
+
+    }
+
+}
+
+// 
+//  Map logic
+// 
+
+map.on('load', function () {
+
+    loadMapLayers();
+
+    addMapInteractions();
+
+});
+
+//
+// Map functions
+//
+
+function loadMapLayers() {
+
+
+    // Map data sources
+
+    map.addSource('sheet-data', {
+        'type': 'geojson',
+        'data': null
+    });
+
+    map.addSource('helsinki', {
+        'type': 'raster',
+        'tiles': [
+            'https://kartta.hel.fi/ws/geoserver/avoindata/wms?SERVICE=WMS&REQUEST=GetMap&SERVICE=WMS&VERSION=1.1.1&LAYERS=Vinovalovarjoste_2017_MDHS_varipinta_05m&STYLES=&FORMAT=image/png&BGCOLOR=0xFFFFFF&TRANSPARENT=TRUE&SRS=epsg:3857&bbox={bbox-epsg-3857}&WIDTH=256&HEIGHT=256'
+        ],
+        'tileSize': 256
+    });
+
+    map.addSource('noise', {
+        'type': 'raster',
+        'tiles': [
+            'https://kartta.hel.fi/ws/geoserver/avoindata/wms?SERVICE=WMS&REQUEST=GetMap&SERVICE=WMS&VERSION=1.1.1&LAYERS=Meluselvitys_2017_alue_01_tieliikenne_L_Aeq_paiva&STYLES=&FORMAT=image/png&BGCOLOR=0xFFFFFF&TRANSPARENT=TRUE&SRS=epsg:3857&bbox={bbox-epsg-3857}&WIDTH=256&HEIGHT=256'
+        ],
+        'tileSize': 256
+    });
+
+    // Map layers
+
+    map.addLayer({
+            'id': 'helsinkilayer',
+            'type': 'raster',
+            'source': 'helsinki',
+            'layout': {
+                'visibility': 'none'
+            }
+        },
+        'aeroway-line'
+    );
+
+    map.addLayer({
+            'id': 'noiselayer',
+            'type': 'raster',
+            'source': 'noise',
+            'layout': {
+                'visibility': 'none'
+            }
+        },
+        'aeroway-line'
+    );
+
+    map.addLayer({
+            'id': 'sheet-data',
+            'type': 'circle',
+            'source': 'sheet-data',
+            'paint': {
+                'circle-color': 'red'
+            }
+        },
+        'aeroway-line'
+    );
+
+    // Request spreadsheet data
+    // https://docs.google.com/spreadsheets/d/1xdQ4APVwv0hKdVTZNcGdQIg1IWEHaUT-zd7T1WczQQI/edit?usp=sharing
+    var sheetId = '1xdQ4APVwv0hKdVTZNcGdQIg1IWEHaUT-zd7T1WczQQI';
+    var sheetName = 'Taulukko1';
+
+    fetch(`https://docs.google.com/spreadsheets/d/${sheetId}/gviz/tq?tqx=out:csv&sheet=${sheetName}`)
+        .then(resp => resp.text())
+        .then(data => {
+            csv2geojson.csv2geojson(data, {
+                latfield: 'Latitude',
+                lonfield: 'Longitude',
+                delimiter: ','
+            }, function (err, data) {
+                map.getSource('sheet-data').setData(data)
+            })
+        })
+
+}
+
+
+//
+// Add map interactions
+//
+
+function addMapInteractions() {
+
+    // When a click event occurs on a feature in the csvData layer, open a popup at the
+    // location of the feature, with description HTML from its properties.
+    map.on('click', 'sheet-data', function (e) {
+
+        var row = e.features[0];
+        var coordinates = row.geometry.coordinates.slice();
+
+        //You can adjust the values of the popup to match the headers of your CSV. 
+        // For example: e.features[0].properties.Name is retrieving information from the field Name in the original CSV. 
+        var description = `<h4>${row.properties.place}</h4>`;
+        description += `<audio controls><source src="#" type="audio/ogg"></audio>`
+        description += `<p>${row.properties["file name / link"]}</p>`
+        description += `<p>${row.properties.comments}</p>`
+        description += `<p>${row.properties.topics}</p>`
+
+        console.log(row)
+
+        // Ensure that if the map is zoomed out such that multiple
+        // copies of the feature are visible, the popup appears
+        // over the copy being pointed to.
+        while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
+            coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
+        }
+
+        //add Popup to map
+
+        new mapboxgl.Popup({
+                maxWidth: '300'
+            })
+            .setLngLat(coordinates)
+            .setHTML(description)
+            .addTo(map);
+    });
+
+    // inspect a cluster on click
+    map.on('click', 'sheet-data', function (e) {
+
+        var features = map.queryRenderedFeatures(e.point, {
+            layers: ['sheet-data']
+        });
+
+        map.easeTo({
+            center: features[0].geometry.coordinates
+        });
+
+    });
+
+    // Change the cursor to a pointer when the mouse is over the places layer.
+    map.on('mouseenter', 'sheet-data', function () {
+        map.getCanvas().style.cursor = 'pointer';
+    });
+
+    // Change it back to a pointer when it leaves.
+    map.on('mouseleave', 'sheet-data', function () {
+        map.getCanvas().style.cursor = '';
+    });
+}
+
+//
+// Other functions
+//
+
+var transformRequest = (url, resourceType) => {
+    var isMapboxRequest =
+        url.slice(8, 22) === "api.mapbox.com" ||
+        url.slice(10, 26) === "tiles.mapbox.com";
+    return {
+        url: isMapboxRequest ?
+            url.replace("?", "?pluginName=sheetMapper&") : url
+    };
+};


### PR DESCRIPTION
General

- Split js into a separate map.js file
- Move baselayer switcher to top left
- Disable history and noise layer by default

Spreadsheet data

- Import data points live from `mediataulukko` spreadsheet
- Plot red circles for any rows with gps coordinates
- Add popups for each marker with limited info: place, comments and topic.
- Audio control to test serving audio directly from google drive ✅ 

Note that all audio is the same file. Problem google drive media links are not yet getting exported, only the link text. eg. `audio-160620-001.mp3`  🔴 . Will need to have these as proper links in the spreadhsheet to be usable `https://drive.google.com/file/d/1NkidoHu_b9DUt-Jqnq2HKhbTSfA8wftA/view?usp=sharing`


<img width="931" alt="Screen Shot 2020-09-20 at 2 02 23 AM" src="https://user-images.githubusercontent.com/126868/93703342-7aa04500-fae5-11ea-81ba-634394679231.png">


@susannaanas @aliakbarmehta 

